### PR TITLE
Fix travis run error

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,10 +1,9 @@
 name: Python package
 
-on: [push, pull-request]
+on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 dist: jammy
 language: python
 python:
-  - "3.10"
+ # - "3.10"
   - "3.11"
 
 before_install: python -m pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.10"
  # - "3.11" not supported by travis up to Ubuntu 22.04 (Jammy)
 
-before_install: python -m pip install --upgrade pip
+before_install: python -m pip3 install --upgrade pip
 install: pip install -r requirements_dev.txt # tox-travis
 
 # Command to run tests, e.g. python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: jammy
 language: python
 python:
   - "3.10"
- # - "3.11" not supported by travis up to Ubuntu 22.04 (Jammy)
+  - "3.11"
 
 before_install: python -m pip install --upgrade pip
 install: pip install -r requirements_dev.txt # tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.10"
  # - "3.11" not supported by travis up to Ubuntu 22.04 (Jammy)
 
-before_install: python -m pip3 install --upgrade pip
+before_install: python -m pip install --upgrade pip
 install: pip install -r requirements_dev.txt # tox-travis
 
 # Command to run tests, e.g. python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 # Config file for automatic testing at travis-ci.com
 
+dist: jammy
 language: python
 python:
-  - 3.10
+  - "3.10"
+ # - "3.11" not supported by travis up to Ubuntu 22.04 (Jammy)
 
-# Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox-travis
+before_install: python -m pip install --upgrade pip
+install: pip install -r requirements_dev.txt # tox-travis
 
 # Command to run tests, e.g. python setup.py test
 script: tox
@@ -23,4 +25,4 @@ deploy:
   on:
     tags: true
     repo: domthom21/eurocodedesign
-    python: 3.8
+    python: 3.10

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ wheel==0.33.6
 watchdog==0.9.0
 flake8==3.7.8
 tox==3.14.0
-coverage==4.5.4
+coverage==7.2.2
 Sphinx==1.8.5
 twine==1.14.0
 pandas==1.5.3


### PR DESCRIPTION
Uses newest travis supported Ubuntu version Jammy/Ubuntu 22.04, now.

Fixes #23 