### PR TITLE
Fix security alerts from dependabot

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
-pip==19.2.3
+pip==22.0.4
 bump2version==0.5.11
-wheel==0.33.6
+wheel==0.38.1
 watchdog==0.9.0
 flake8==3.7.8
 tox==3.14.0


### PR DESCRIPTION
Update required pip from 19.2.3 to 22.0.4 and
wheel from 0.33.6 to 0.38.1 in requirements_dev.txt