### PR TITLE
Add national annex functionality

### DIFF
--- a/eurocodedesign/core/NA.py
+++ b/eurocodedesign/core/NA.py
@@ -1,0 +1,95 @@
+"""
+National annex module
+
+This module enables the use of setting the country code from which national
+defined parameters should be used. NDP-supporting functions are annotated with
+the @NDP decorator.
+
+Example:
+    ::
+
+        >>> from eurocodedesign.core.NA import set_country
+        >>> import eurocodedesign.standard.ec3 as ec3
+        >>> ec3.gamma_M1()
+        ... 1.00
+        >>> set_country('de')
+        >>> ec3.gamma_M1()
+        ... 1.10
+        >>> ec3.gamma_M1(country=None)
+        ... 1.00
+
+"""
+from functools import wraps
+from typing import ParamSpec, TypeVar, Callable
+
+from eurocodedesign.core.typing import NACountry
+
+_NA_country: NACountry = None
+
+_P = ParamSpec('_P')
+_T = TypeVar('_T')
+
+
+def NDP(func: Callable[_P, _T]) -> Callable[_P, _T]:
+    """Decorator for functions supporting NDPs
+
+    This decorator indicates if the following function supports national
+    defined parameters (NDPs). The function must support a `country` argument
+    for setting the national annex manually and must contain code which
+    respects the national annex.
+
+    Args:
+        func: the function to wrap
+
+    Returns: the wrapped function
+    """
+    @wraps(func)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def set_country(country: NACountry) -> None:
+    """Set the national annex country code
+
+    If no country code is given, the national annex is neglected and given
+    values from the main standard are taken.
+
+    If no national defined parameters exists, each called function looking
+     for a NDP raises a ValueError
+
+    Args:
+        country: country code according to ISO-3166-1 ALPHA-2 or None
+
+    Returns: None
+    """
+    global _NA_country
+    _NA_country = country
+
+
+def load_NDP(key: str,
+             default: str = '',
+             country: NACountry = None) -> str:
+    """Load a specific NDP by key from country
+
+    Conversion to float or int must be done by user
+
+    Args:
+        key: key of NDP to load
+        default: default value to use
+        country: country code according to ISO-3166-1 ALPHA-2 or None
+
+    Returns: value as string
+
+    """
+    import pandas as pd
+    from pathlib import Path
+
+    country = _NA_country if country is None else country
+    # No NA in general set, return default value
+    if country is None:
+        return default
+    file = country + '.csv'
+    path = Path(__file__).parent.parent / 'standard' / '_NA' / file
+    df = pd.read_csv(path, index_col="NDP_key")
+    return str(df['value'].get(key, default=default))

--- a/eurocodedesign/core/typing/__init__.py
+++ b/eurocodedesign/core/typing/__init__.py
@@ -9,6 +9,7 @@ FloatSequence: TypeAlias = Sequence[float]
 FloatTriple: TypeAlias = Tuple[float, float, float]
 MeterTriple: TypeAlias = Tuple[Meter, Meter, Meter]
 PascalSequence: TypeAlias = Sequence[Pascal]
+NACountry: TypeAlias = str | None
 
 """TypeAlias for the load factor ```\\eta`` """
 Eta: TypeAlias = float

--- a/eurocodedesign/standard/_NA/de.csv
+++ b/eurocodedesign/standard/_NA/de.csv
@@ -1,0 +1,4 @@
+NDP_key,version,value,description,comment,comment_local
+"EN1993-1-1_6.1_note_2b#gamma_M0","2010-12","1.0","gamma_M1","","Für Hochbauten"
+"EN1993-1-1_6.1_note_2b#gamma_M1","2010-12","1.1","gamma_M1","","Für Hochbauten"
+"EN1993-1-1_6.1_note_2b#gamma_M2","2010-12","1.25","gamma_M1","","Für Hochbauten"

--- a/eurocodedesign/standard/ec3/__init__.py
+++ b/eurocodedesign/standard/ec3/__init__.py
@@ -1,41 +1,58 @@
-def gamma_M0() -> float:
-    """
-    Partial factor ``\\gamma_{M0}`` for buildings
+import eurocodedesign as ed
+from eurocodedesign.core.NA import NDP
+from eurocodedesign.core.typing import NACountry
+
+
+@NDP
+def gamma_M0(country: NACountry = None) -> float:
+    r"""
+    Partial factor :math:`\gamma_{M0}` for buildings
 
     Partial factor for resistance of cross-sections (whatever the class is).
     Value according to EN 1993-1-1:2010-12 §6.1 (1)
 
-    Returns: ``\\gamma_{M0}``
+    Returns: :math:`\gamma_{M0}` for current country
 
     """
-    gamma_M0 = 1.00
+    gamma_M0: float = float(
+        ed.core.NA.load_NDP(key='EN1993-1-1_6.1_note_2b#gamma_M0',
+                            default='1.00',
+                            country=country))
     return gamma_M0
 
 
-def gamma_M1() -> float:
-    """
-    Partial factor ``\\gamma_{M1}`` for buildings
+@NDP
+def gamma_M1(country: NACountry = None) -> float:
+    r"""
+    Partial factor :math:`\gamma_{M1}` for buildings
 
     Partial factor for resistance of members to instability assessed by
     member checks.
     Value according to EN 1993-1-1:2010-12 §6.1 (1)
 
-    Returns: ``\\gamma_{M1}``
+    Returns: :math:`\gamma_{M1}` for current country
 
     """
-    gamma_M1 = 1.00
+    gamma_M1: float = float(
+        ed.core.NA.load_NDP(key='EN1993-1-1_6.1_note_2b#gamma_M1',
+                            default='1.00',
+                            country=country))
     return gamma_M1
 
 
-def gamma_M2() -> float:
-    """
-    Partial factor ``\\gamma_{M2}`` for buildings
+@NDP
+def gamma_M2(country: NACountry = None) -> float:
+    r"""
+    Partial factor :math:`\gamma_{M2}` for buildings
 
     Partial factor for resistance of cross-sections in tension to fracture.
     Value according to EN 1993-1-1:2010-12 §6.1 (1)
 
-    Returns: ``\\gamma_{M2}``
+    Returns: :math:`\gamma_{M2}` for current country
 
     """
-    gamma_M2 = 1.25
+    gamma_M2: float = float(
+        ed.core.NA.load_NDP(key='EN1993-1-1_6.1_note_2b#gamma_M2',
+                            default='1.25',
+                            country=country))
     return gamma_M2

--- a/tests/core/test_NA.py
+++ b/tests/core/test_NA.py
@@ -1,0 +1,19 @@
+import eurocodedesign as ed
+import eurocodedesign.core.NA
+from eurocodedesign.standard import ec3
+
+
+def test_NA():
+    assert ec3.gamma_M1() == 1.00
+    country = 'de'
+    assert float(ed.core.NA.load_NDP(key='EN1993-1-1_6.1_note_2b#gamma_M1',
+                                     country=country)) == 1.10
+    assert ec3.gamma_M1() == 1.00
+    ed.core.NA.set_country(country='de')
+    assert ec3.gamma_M0() == 1.00
+    assert ec3.gamma_M1() == 1.10
+    assert ec3.gamma_M2() == 1.25
+    ed.core.NA.set_country(None)
+    assert ec3.gamma_M0() == 1.0
+    assert ec3.gamma_M1() == 1.0
+    assert ec3.gamma_M2() == 1.25


### PR DESCRIPTION
Allow simple usage and adaptability of eurocodedesign for national annexes.

Add module eurocodedesign.core.NA
Add NDP eurocodedesign/standard/_NA/de.csv
Modify eurocodedesign.standard.ec3.gamma_Mi to use NDP